### PR TITLE
Add the transformModuleName option to manage the "moduleName" traceur option (very usefull when we use the System loader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,122 @@ module.exports = function(config) {
       // custom filename transformation function
       transformPath: function(path) {
         return path.replace(/\.es6$/, '.js');
+      },
+      // custom module name transformation function. By default: none
+      transformModuleName: function(originalPath, transformedPath) {
+        return path;
       }
     }
   });
 };
 ```
+
+## Transform Module Name
+
+This option is very usefull when we want to use other loaders like the SystemJs. Here a basic example:
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    // at a minimum need requirejs + traceur
+    frameworks: ['jasmine', 'traceur'],
+
+    preprocessors: {
+      'src/**/*.es6': ['traceur']
+    },
+
+    files: [
+      'node_modules/es6-module-loader/dist/es6-module-loader.src.js',
+      'node_modules/systemjs/dist/system.src.js',
+      {pattern: 'src/**/*.es6', included: true},
+      {pattern: 'test/**/*Spec.es6', included: true},
+      'test/system.conf.js'
+    ],
+
+    // default configuration, not required
+    traceurPreprocessor: {
+      // options passed to the traceur-compiler
+      // see traceur --longhelp for list of options
+      options: {
+        sourceMaps: true,
+        modules: 'instantiate'
+      },
+      // custom filename transformation function
+      transformPath: function(path) {
+        return path.replace(/\.es6$/, '.js');
+      },
+      // custom module name transformation function. By default: none
+      transformModuleName: function(originalPath, transformedPath) {
+        var tempPath = originalPath.substr(__dirname.length + 1);
+        return tempPath.substr(0, tempPath.length - 3); // An original path like 'c:/Users/aUser/MyProject/src/index.js' will become 'src/index'
+      }
+    }
+  });
+};
+```
+
+Here an example of the 'test/system.conf.js' file:
+
+```js
+/*jshint camelcase: false, -W083*/
+/*global System: true */
+
+(function (karma) {
+    'use strict';
+
+    karma.loaded = function() { }; // make it async
+
+    var
+        /**
+         * All tests collected
+         * @type {string[]}
+         */
+        tests = [],
+
+        loadedTestFileInc = 0;
+
+    /**
+     * Try to start karma (do it only when all test files are loaded)
+     *
+     * @method
+     * @private
+     */
+    function _tryStartKarma() {
+        loadedTestFileInc++;
+
+        if (loadedTestFileInc === tests.length) {
+            karma.start();
+        }
+    }
+
+    // Filter tests files
+    for (var file in karma.files) {
+        if (karma.files.hasOwnProperty(file)) {
+            if (/Spec\.js$/.test(file)) {
+                tests.push(file);
+            }
+        }
+    }
+
+    // Load tests files
+    for (var i = 0, modulePath; i < tests.length; ++i) {
+        modulePath = tests[i];
+        modulePath = modulePath.substr(6);
+        modulePath = modulePath.substr(0, modulePath.length - 3);
+
+        console.info('Load test: ' + modulePath);
+
+        System
+            .import(modulePath)
+            .then(_tryStartKarma)
+            .catch(function (ex) {
+                console.error(ex.stack || ex);
+                _tryStartKarma();
+            });
+    }
+})(window.__karma__);
+```
+
 
 ## Source Maps
 If you set the `sourceMaps`  preprocessor option to `true` then the generated source map will be inlined as a data-uri.

--- a/index.js
+++ b/index.js
@@ -14,12 +14,21 @@ var createTraceurPreprocessor = function(args, config, logger, helper) {
     return filepath.replace(/\.es6.js$/, '.js').replace(/\.es6$/, '.js');
   };
 
+  var transformModuleName = args.transformModuleName || config.transformModuleName;
+
   return function(content, file, done) {
     log.debug('Processing "%s".', file.originalPath);
     file.path = transformPath(file.originalPath);
     var filename = file.originalPath;
+    var duplicatedOptions = helper.merge({ }, options);
+
+    if (transformModuleName) {
+      // Set the name of the module for this file
+      duplicatedOptions.moduleName = transformModuleName(file.originalPath, file.path);
+    }
+
     var transpiledContent;
-    var compiler = new traceur.NodeCompiler(options);
+    var compiler = new traceur.NodeCompiler(duplicatedOptions);
 
     try {
       transpiledContent = compiler.compile(content, filename);


### PR DESCRIPTION
I make a project with traceur and I used the "es6-module-loader" and "systemjs" workflow to load my modules.

However, I need to set the module name (otherwise, traceur seems to set the path to the file). Moreover if we use absolute path to import the modules. So, I extend the preprocessor to allow this functionality.

What do you think about this ?