### PR TITLE
Only build sourcemap if transpilation was successful

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,19 +23,20 @@ var createTraceurPreprocessor = function(args, config, logger, helper) {
 
     try {
       transpiledContent = compiler.compile(content, filename);
+
+      if (compiler.getSourceMap() !== undefined) {
+        var map = JSON.parse(compiler.getSourceMap());
+        map.file = file.path;
+        transpiledContent += '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,';
+        transpiledContent += new Buffer(JSON.stringify(map)).toString('base64') + '\n';
+        file.sourceMap = map;
+      }
+
+      done(null, transpiledContent);
     } catch (e) {
       log.error(e);
       done(new Error('TRACEUR COMPILE ERROR\n', e.toString()));
     }
-
-    if (compiler.getSourceMap() !== undefined) {
-      var map = JSON.parse(compiler.getSourceMap());
-      map.file = file.path;
-      transpiledContent += '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,';
-      transpiledContent += new Buffer(JSON.stringify(map)).toString('base64') + '\n';
-      file.sourceMap = map;
-    }
-    return done(null, transpiledContent);
   };
 };
 


### PR DESCRIPTION
Sourcemap processing was erroring out killing my watch process. This
moves the sourcemap processing up in to the try block so it will
only happen if the transpile succeeds.

Before:

```
INFO [watcher]: Changed file "/Users/dholst/Projects/frontend/src/app/common/feature/feature.service.js".
ERROR [preprocessor.traceur]: [ '/Users/dholst/Projects/frontend/src/app/common/feature/feature.service.js:49:11: Unexpected token return' ]
ERROR [karma]: [TypeError: Not a string or buffer]
TypeError: Not a string or buffer
  at TypeError (native)
  at Hash.update (crypto.js:70:16)
  at sha1 (/Users/dholst/Projects/frontend/node_modules/karma/lib/preprocessor.js:11:8)
  at nextPreprocessor (/Users/dholst/Projects/frontend/node_modules/karma/lib/preprocessor.js:44:20)
  at /Users/dholst/Projects/frontend/node_modules/karma-traceur-preprocessor/index.js:38:12
  at nextPreprocessor (/Users/dholst/Projects/frontend/node_modules/karma/lib/preprocessor.js:48:28)
  at /Users/dholst/Projects/frontend/node_modules/karma/lib/preprocessor.js:86:7
  at FSReqWrap.readFileAfterClose [as oncomplete] (evalmachine.<anonymous>:380:3)

[13:47:32] 'test:watch' errored after 13 s
[13:47:32] Error: 1
  at formatError (/Users/dholst/Projects/frontend/node_modules/gulp/bin/gulp.js:169:10)
  at Gulp.<anonymous> (/Users/dholst/Projects/frontend/node_modules/gulp/bin/gulp.js:195:15)
  at emitOne (events.js:77:13)
  at Gulp.emit (events.js:169:7)
  at Gulp.Orchestrator._emitTaskDone (/Users/dholst/Projects/frontend/node_modules/gulp/node_modules/orchestrator/index.js:264:8)
  at /Users/dholst/Projects/frontend/node_modules/gulp/node_modules/orchestrator/index.js:275:23
  at finish (/Users/dholst/Projects/frontend/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:21:8)
  at cb (/Users/dholst/Projects/frontend/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:29:3)
  at removeAllListeners (/Users/dholst/Projects/frontend/node_modules/karma/lib/server.js:215:7)
  at Server.<anonymous> (/Users/dholst/Projects/frontend/node_modules/karma/lib/server.js:226:9)
  at Server.g (events.js:260:16)
  at emitNone (events.js:72:20)
  at Server.emit (events.js:166:7)
  at emitCloseNT (net.js:1518:8)
  at doNTCallback1 (node.js:418:9)
  at process._tickCallback (node.js:340:17)

~/Projects/frontend (FRT-424) ✗
✗
```

After:

```
INFO [watcher]: Changed file "/Users/dholst/Projects/frontend/src/app/common/feature/feature.service.js".
ERROR [preprocessor.traceur]: [ '/Users/dholst/Projects/frontend/src/app/common/feature/feature.service.js:49:11: Unexpected token return' ]
PhantomJS 2.0.0 (Mac OS X 0.0.0) ERROR
  TEST RUN WAS CANCELLED because this file contains some errors:
    /Users/dholst/Projects/frontend/src/app/common/feature/feature.service.js
PhantomJS 2.0.0 (Mac OS X 0.0.0): Executed 0 of 0 ERROR (0.256 secs / 0 secs)
```
